### PR TITLE
fix disconnect between answers and playground notes

### DIFF
--- a/W1D1-Answers.txt
+++ b/W1D1-Answers.txt
@@ -11,12 +11,14 @@ count = count + 1
 
 //: ## Challenge 3
 
-// The types of count (Int) and greeting (String) don't match up, so there is a syntax error and the playground won't run.
+// tipAmount's type is: Double
+// isOpen's type is: Bool
+
 
 //: ## Challenge 4
 
-// tipAmount's type is: Double
-// isOpen's type is: Bool
+// The types of count (Int) and height (Double) don't match up, so there is a syntax error and the playground won't run.
+
 
 //: ## Bonus Challenge
 

--- a/W1D1-VariablesAndTypes.playground/Contents.swift
+++ b/W1D1-VariablesAndTypes.playground/Contents.swift
@@ -85,6 +85,7 @@ var isOpen = true
 
 var height: Double = 10
 
+//: ### Challenge 4
 //: Since all our variables have types, even if we haven't specifically set them, we can't store any value in them... only values of the right type.
 //: Test this out. Try setting the value of `count` to be `height`:
 


### PR DESCRIPTION
The answers referenced 4 challenges and a bonus challenge while the playground file only mentioned 3 challenges and bonus challenge. 
